### PR TITLE
feat(cli): add --amend option to improve commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ After generating commit messages, you can:
 - `-d, --debug` - Show basic debug info in console
 - `--debug-file <path>` - Write detailed debug logs to file (use '-' for stdout)
 - `--auto-commit` - Automatically commit with the generated message
+- `--amend` - Amend the last commit with the generated message (useful with Git hooks)
 - `--api-key <key>` - Provide API key directly
 - `--api-endpoint <url>` - Custom API endpoint URL
 - `-p, --print-once` - Disable streaming output
@@ -157,3 +158,60 @@ Contributions are welcome! Feel free to open issues and pull requests.
 ## License
 
 Licensed under MIT - see the [LICENSE](LICENSE) file for details.
+
+### Using turboCommit with --amend
+
+The `--amend` option allows you to change the commit message of your last commit. This is useful when:
+- You want to improve the message of your last commit
+- You want to fix a typo in your commit message
+- You want to add more context to your commit message
+
+Usage:
+```bash
+# First, make sure you have no staged changes
+git status  # Should show no staged changes
+
+# Then use --amend to improve the last commit's message
+turbocommit --amend  # This will analyze the last commit's changes and suggest a new message
+```
+
+Important Notes:
+- When using `--amend`, you must not have any staged changes
+- The tool will analyze only the changes from your last commit
+- If you want to include new changes in the amended commit:
+  1. Either commit them first normally, then amend that commit
+  2. Or use `git commit --amend` manually to include them
+
+You can also combine this with auto-commit for a quick message update:
+```bash
+turbocommit --amend --auto-commit  # Automatically amend with the first generated message
+```
+
+### Using turboCommit with Git Hooks
+
+If your project uses Git hooks (e.g., linters, formatters), here's how to use turboCommit effectively:
+
+1. Stage and commit your changes normally:
+```bash
+git add .
+turbocommit
+```
+
+2. If hooks fail:
+   - Fix the issues reported by hooks
+   - Stage the fixed files (`git add .`)
+   - Commit again
+
+3. If you want to improve the commit message after all hooks pass:
+```bash
+# Make sure you have no staged changes
+git status
+
+# Then improve the message
+turbocommit --amend  # This will analyze the commit and suggest a better message
+```
+
+This workflow ensures that:
+- Code quality checks run before the commit
+- You can improve the commit message after all checks pass
+- The final commit message is high-quality and descriptive

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -126,14 +126,14 @@ impl Actor {
 
             match Task::from_str(task) {
                 Task::Commit => {
-                    match git::commit(message) {
+                    match git::commit(message, self.options.amend) {
                         Ok(_) => {}
                         Err(e) => {
                             println!("{e}");
                             process::exit(1);
                         }
                     };
-                    println!("{} 🎉", "Commit successful!".purple());
+                    println!("{} 🎉", if self.options.amend { "Commit message amended!" } else { "Commit successful!" }.purple());
                     break;
                 }
                 Task::Edit => {
@@ -177,7 +177,7 @@ impl Actor {
             return Err(anyhow::anyhow!("No commit message generated"));
         }
         let message = choices[0].clone();
-        git::commit(message.clone())?;
+        git::commit(message.clone(), self.options.amend)?;
         Ok(message)
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,7 @@ pub struct Options {
     pub debug_file: Option<String>,
     pub always_select_files: bool,
     pub config_file: Option<String>,
+    pub amend: bool,
 }
 
 impl From<&Config> for Options {
@@ -48,6 +49,7 @@ impl From<&Config> for Options {
             debug_file: None,
             always_select_files: false,
             config_file: None,
+            amend: false,
         }
     }
 }
@@ -130,6 +132,9 @@ impl Options {
                     opts.auto_commmit = true;
                     opts.n = 1;
                     opts.print_once = true;
+                }
+                "--amend" => {
+                    opts.amend = true;
                 }
                 "--check-version" => {
                     opts.check_version_only = true;
@@ -259,6 +264,7 @@ fn help() {
             .bright_black()
     );
     println!("  --auto-commit  Automatically generate and commit a single message\n");
+    println!("  --amend  Amend the last commit with the generated message\n");
     println!("  --check-version  Check for updates and exit\n");
     println!("  --api-endpoint <url>  Set the API endpoint URL\n");
     println!("  --system-msg-file <path>  Load system message from a file\n");

--- a/src/git.rs
+++ b/src/git.rs
@@ -60,11 +60,53 @@ pub fn diff(repo: &Repository, files: &[String]) -> Result<String, git2::Error> 
 //     Ok(())
 // }
 
-pub fn commit(msg: String) -> anyhow::Result<()> {
-    Command::new("git")
-        .arg("commit")
-        .arg("-m")
-        .arg(msg)
-        .output()?;
+pub fn get_last_commit_diff(repo: &Repository) -> Result<String, git2::Error> {
+    let mut ret = String::new();
+    let head = repo.head()?;
+    let head_commit = head.peel_to_commit()?;
+    
+    if let Some(parent) = head_commit.parent(0).ok() {
+        let diff = repo.diff_tree_to_tree(
+            Some(&parent.tree()?),
+            Some(&head_commit.tree()?),
+            None,
+        )?;
+        
+        diff.print(git2::DiffFormat::Patch, |_, _, line| {
+            ret.push(line.origin());
+            ret.push_str(std::str::from_utf8(line.content()).unwrap_or(""));
+            true
+        })?;
+    }
+    Ok(ret)
+}
+
+pub fn has_staged_changes(repo: &Repository) -> Result<bool, git2::Error> {
+    let idx = repo.index()?;
+    let mut head: Option<Tree> = None;
+    if let Ok(h) = repo.head() {
+        head = Some(h.peel_to_tree()?);
+    }
+    let diff = repo.diff_tree_to_index(head.as_ref(), Some(&idx), None)?;
+    Ok(diff.deltas().len() > 0)
+}
+
+pub fn commit(message: String, amend: bool) -> anyhow::Result<()> {
+    let mut cmd = Command::new("git");
+    cmd.arg("commit");
+    if amend {
+        cmd.arg("--amend");
+        // When amending, we don't need staged changes
+        cmd.arg("--no-edit"); // This prevents git from opening the editor
+    }
+    cmd.arg("-m").arg(message);
+    
+    let output = cmd.output()?;
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
     Ok(())
 }


### PR DESCRIPTION
This pull request introduces a new `--amend` option to the `turbocommit` tool, which allows users to amend the last commit with a generated message. The changes span across multiple files, including documentation updates, command-line interface modifications, and core functionality adjustments.

### Documentation Updates:
* Added a description and usage instructions for the new `--amend` option in the `README.md` file. This includes scenarios where the option is useful, usage examples, and important notes.
* Updated the command-line options section in the `README.md` to include the `--amend` option.

### Command-Line Interface Modifications:
* Introduced the `amend` field in the `Options` struct in `src/cli.rs` and updated the relevant methods to handle the `--amend` flag. [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR28) [[2]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR52) [[3]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR136-R138) [[4]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR267)

### Core Functionality Adjustments:
* Modified the `commit` function in `src/git.rs` to support the `--amend` option, ensuring that it can amend the last commit message without requiring staged changes.
* Updated the `Actor` implementation in `src/actor.rs` to handle the `amend` option during the commit process, providing appropriate messages based on whether the commit was amended or newly created. [[1]](diffhunk://#diff-9749c81c451c5ee39af38e72bdca1c6ed288534831f70214e74247074cc6b8aaL129-R136) [[2]](diffhunk://#diff-9749c81c451c5ee39af38e72bdca1c6ed288534831f70214e74247074cc6b8aaL180-R180)
* Enhanced the main function in `src/main.rs` to incorporate logic for handling the `--amend` option, including checks for staged changes and retrieving the diff of the last commit.